### PR TITLE
fix: pays-9992 - post to the head commit instead of after

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ async function run() {
   console.log(JSON.stringify(context, null, 2));
   const sha = context.payload.after;
   const prefix = s3KeyPrefix || `coverage/${context.payload.repository.full_name}`;
+  const head = context.payload.pull_request && context.payload.pull_request.head.sha;
   const baseGitCommit = (context.payload.pull_request || { base: {} }).base.sha;
   const prNumber = (context.payload.pull_request || {}).number;
   const prUrl = (context.payload.pull_request || {}).html_url;
@@ -139,7 +140,7 @@ async function run() {
     createCommitStatus({
       client,
       context,
-      sha,
+      sha: head,
       status: generateStatus({ targetUrl: prUrl, metric, statusContext }),
     });
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Problem

When opening a PR to any repo, for example Paysite Frontend, the Test MA and Test Tour actions would fail due to a bad `POST` request to the GitHub API.

Example here:  
https://github.com/gmsllc/paysite-frontend/actions/runs/6184732424/job/16789232530#step:4:623

The issue is that there should be a route parameter which is the commit hash. The hash used before was `payload.after` but this isn't always present, resulting in a malformed request. This value is present when amending a commit or pushing a second commit to a PR, so we worked around this by adding a second commit or amending the first one and force-pushing. 

However, `payload.pull_request.head.sha` is always present for pull requests, so that's probably a better candidate to use instead. I have tested this in an HTTP client, and it does add the status successfully.